### PR TITLE
add: index.html appKey 설정, localhost 포트번호 설정

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,9 +16,13 @@
   <body>
     <div id="root"></div>
     <script
-      t
-      ype="module"
+      type="module"
       src="/src/main.jsx"
     ></script>
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_MAP_API_KEY%"
+    >
+    </script>
   </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react-swc'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 3000
+  }
 })


### PR DESCRIPTION
## What is this PR? 🔍
카카오맵 api 사용할 때 필요한 설정했습니다!
- localhost 포트번호 설정 (지정해둔 도메인에서만 사용할 수 있어서 3000으로 등록해뒀고, 다들 거기서 실행될 수 있도록 설정했습니다.)
- index.html API_KEY 설정

<br/>

## Screenshot 📸
<img width="597" alt="image" src="https://github.com/user-attachments/assets/519c865f-ed15-4761-8e86-4b175855d35a">

카카오맵 API로 띄운 맵

<br/>

## Test Checklist ☑️
- [x] 실행시 API로 맵 관련 메서드 등 사용 가능한 것 확인 완료

<br/>

## Others 👻
- yarn dev 했을 때 혹시 포트번호 3000으로 안뜨는 분 계시면 알려주세여!