### PR TITLE
feat: 페이지 이동시 페이지 최상단으로 scroll 이동

### DIFF
--- a/src/shared/Router.jsx
+++ b/src/shared/Router.jsx
@@ -9,10 +9,12 @@ import Form from './../pages/Form';
 import Detail from './../pages/Detail';
 import NotAuthenticatedRoute from './NotAuthenticatedRoute.jsx';
 import AuthenticatedRoute from './AuthenticatedRoute.jsx';
+import ScrollToTop from './ScrollToTop.jsx';
 
 const Router = () => {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <Routes>
         <Route
           path='/'

--- a/src/shared/ScrollToTop.jsx
+++ b/src/shared/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
## What is this PR? 🔍
- 페이지 이동시 스크롤이 이전 페이지의 위치에 있어 최상단으로 이동하도록 ScrollToTop 컴포넌트 추가했습니다.

<br/>

## Screenshot 📸
- 수정 전 
![ScrollTop 추가 전](https://github.com/user-attachments/assets/f58cb0c5-3956-4af6-b465-f549b18b7088)

- 수정 후 
![ScrollTop 추가 후](https://github.com/user-attachments/assets/0fd364e0-9716-4b25-8123-01c23dab8ff9)


<br/>

## Test Checklist ☑️
- [x] 모든 페이지에서 적용되는 것 확인

<br/>

## Others 👻
- 이전 페이지의 스크롤 위치가 유지되어야하는 경우가 있다면 알려주세요!