### PR TITLE
Fix/mypage like: mypage, detail 내 FavoriteButton 추가

### DIFF
--- a/src/components/FavoriteButton.jsx
+++ b/src/components/FavoriteButton.jsx
@@ -2,7 +2,7 @@ import { Heart } from 'lucide-react';
 import useUserStore from '../stores/useUserStore.js';
 import { useGetFavoritePosts, useToggleFavoritePost } from '../query/userQuery.js';
 import { useEffect, useState } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 const FavoriteButton = ({ postId }) => {
   const { id, isAuthenticated } = useUserStore((state) => state.user);

--- a/src/components/FavoriteButton.jsx
+++ b/src/components/FavoriteButton.jsx
@@ -16,7 +16,7 @@ const FavoriteButton = ({ postId }) => {
     if (isSuccess && isAuthenticated) {
       setIsSelected(favoritePosts.includes(postId));
     }
-  }, [isSuccess]);
+  }, [favoritePosts, isSuccess]);
 
   const { mutateFavoritePosts } = useToggleFavoritePost({ userId: id, postId });
   const handleClick = () => {

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -2,6 +2,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useEffect } from 'react';
 import useUserStore from '../stores/useUserStore';
 import { useGetPostById } from '../query/postQuery';
+import FavoriteButton from '../components/FavoriteButton.jsx';
 
 const Detail = () => {
   const { postId } = useParams();
@@ -39,8 +40,10 @@ const Detail = () => {
 
   return (
     <div className='bg-neutral-200  w-6/12 h-full flex mx-auto my-5 flex-col py-5 px-10 gap-5'>
-      <div className='flex justify-between'>
-        <div>하트</div>
+      <div className='flex justify-between items-center'>
+        <div className='relative w-[30px] h-[30px] top-[-0.25rem] right-[-0.25rem]'>
+          <FavoriteButton postId={postId} />
+        </div>
         <div
           onClick={() => navigate(-1)}
           className='cursor-pointer'

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -10,8 +10,8 @@ const Mypage = () => {
   const { mutate } = useDeletePostById();
   const navigate = useNavigate();
   const handleMoveToDetail = (e, postId) => {
-    if (e.target.classList.contains('deleteButton')) return;
-    if (e.target.classList.contains('favoriteButton')) return;
+    if (e.target.closest('.deleteButton')) return;
+    if (e.target.closest('.favoriteButton')) return;
     navigate(`/detail/${postId}`);
   };
 


### PR DESCRIPTION
## What is this PR? 🔍
- MyPage, Detail 페이지에 Favorite Button 추가
- MyPage의 포스트 카드에서 이벤트 버블링 방지
- MyPage의 내 게시글/좋아요한 게시글 영역에서 같은 게시글의 좋아요 버튼이 동기화되지 않던 문제 수정

<br/>

## Screenshot 📸
- FavoriteButton 동기화, 이벤트버블링으로인한 detail 페이지 이동 방지
![좋아요 버튼 동기화](https://github.com/user-attachments/assets/e342f29a-32f5-4a5c-a0d4-22d8ca1308fe)


<br/>

## Test Checklist ☑️
- [x] 마이페이지에서 좋아요 버튼을 누른 게시글이 map, detail에서도 반영되어 보이는 것 확인

<br/>

## Others 👻
- 좋아요한 게시글에 게시글 카드 표시되는 것은 따로 처리 필요합니다. (현재 두 영역 모두 유저가 작성한 게시글 있는 것 같습니다!)