### PR TITLE
feat: zustand persist를 이용해 유저 상태 유지

### DIFF
--- a/src/shared/AuthenticatedRoute.jsx
+++ b/src/shared/AuthenticatedRoute.jsx
@@ -7,7 +7,7 @@ const AuthenticatedRoute = () => {
   const { pathname } = useLocation();
 
   // 로그인이 안돼있으면
-  if (isAuthenticated === false) {
+  if (!isAuthenticated) {
     return (
       // 로그인 페이지로 보냄
       <Navigate
@@ -16,8 +16,6 @@ const AuthenticatedRoute = () => {
         state={{ redirectedForm: pathname }}
       />
     );
-  } else if (isAuthenticated === null) {
-    return;
   }
 
   return <Outlet />;

--- a/src/stores/useUserStore.js
+++ b/src/stores/useUserStore.js
@@ -1,44 +1,51 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
-const useUserStore = create((set) => ({
-  user: {
-    isAuthenticated: null,
-    id: '',
-    user_id: '',
-    nickname: '',
-    profile_img_url: '',
-    favorite_posts: [],
-  },
-
-  update: () =>
-    set((state) => ({
+const useUserStore = create(
+  persist(
+    (set) => ({
       user: {
-        ...state.user,
-        isAuthenticated: false,
-      },
-    })),
-
-  logout: () =>
-    set(() => ({
-      user: {
-        isAuthenticated: false,
+        isAuthenticated: null,
         id: '',
         user_id: '',
         nickname: '',
         profile_img_url: '',
         favorite_posts: [],
       },
-    })),
 
-  login: (userInfo) =>
-    set(() => ({
-      user: {
-        isAuthenticated: true,
-        ...userInfo,
-      },
-    })),
-}));
+      update: () =>
+        set((state) => ({
+          user: {
+            ...state.user,
+            isAuthenticated: false,
+          },
+        })),
 
-// persist 사용해서 로컬스토리지에 받아오기 전에 초기값으로 될 수 밖에 없는 그 상황 방지..
+      logout: () =>
+        set(() => ({
+          user: {
+            isAuthenticated: false,
+            id: '',
+            user_id: '',
+            nickname: '',
+            profile_img_url: '',
+            favorite_posts: [],
+          },
+        })),
+
+      login: (userInfo) =>
+        set(() => ({
+          user: {
+            isAuthenticated: true,
+            ...userInfo,
+          },
+        })),
+    }),
+    {
+      name: 'user',
+      getStorage: () => sessionStorage,
+    },
+  ),
+);
 
 export default useUserStore;


### PR DESCRIPTION
## What is this PR? 🔍
- url 입력 혹은 새로고침으로 reload 발생시 로그인한 유저도 isAuthenticated 가 false(초기값)이 되었다가 다시 세팅되면서 페이지 이동이 어색한 상황이 발생
- 위 문제를 해결하기위해 zustand persist를 이용해 유저 정보를 session storage에 저장하여 사용
